### PR TITLE
feat: expose patched nixpkgs in specialArgs

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,23 @@ To be extra sure you can use download the patch and reference to it by a local p
 > [!NOTE]  
 > If you are using `fetchpatch`, `fetchpatch2` (or anything that uses `filterdiff` under the hood) instead of `fetchurl`, patching can fail if the only change to any files in the patch is a rename.
 
+## Accessing the Patched Nixpkgs
+
+In your NixOS module you can access the patched nixpkgs as `nixpkgs-patched`.
+It could be useful for example when you want to explicitly import it:
+```nix
+{ nixpkgs-patched, pkgs, ... }:
+
+let
+  pkgs-patched = import nixpkgs-patched {
+    inherit (pkgs) system;
+  };
+in
+{
+  # ...
+}
+```
+
 ## Troubleshooting
 
 See the [troubleshooting documentation](doc/troubleshooting.md).

--- a/flake.nix
+++ b/flake.nix
@@ -84,10 +84,14 @@
             metadataModule
             nixpkgsPatcherNixosModule
           ];
+          specialArgs = (args.specialArgs or { }) // {
+            nixpkgs-patched = finalNixpkgs;
+          };
         }
         // removeAttrs args [
           "modules"
           "nixpkgsPatcher"
+          "specialArgs"
         ];
 
         config = args.nixpkgsPatcher or { };

--- a/tests/expose-patched-nixpkgs/base-configuration.nix
+++ b/tests/expose-patched-nixpkgs/base-configuration.nix
@@ -1,0 +1,13 @@
+{ lib, ... }:
+
+{
+  fileSystems."/" = {
+    device = "nodev";
+  };
+
+  nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
+
+  boot.loader.grub.device = "nodev";
+
+  system.stateVersion = "25.05";
+}

--- a/tests/expose-patched-nixpkgs/flake.lock
+++ b/tests/expose-patched-nixpkgs/flake.lock
@@ -1,0 +1,52 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1749307940,
+        "narHash": "sha256-Zo1AH9079axOQpWqLiaUzbL+NT/k4lSCdCwZMvEvLv4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "dd90a8666b501e6068a1d56fe6f0b1da85ccac06",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "dd90a8666b501e6068a1d56fe6f0b1da85ccac06",
+        "type": "github"
+      }
+    },
+    "nixpkgs-patch-git-review-bump": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-T+beekuqxM6+/EKZVwYmFS2yXnjw1gTl/l7NRjFkirc=",
+        "type": "file",
+        "url": "https://github.com/NixOS/nixpkgs/pull/410328.diff"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://github.com/NixOS/nixpkgs/pull/410328.diff"
+      }
+    },
+    "nixpkgs-patcher": {
+      "locked": {
+        "path": "../..",
+        "type": "path"
+      },
+      "original": {
+        "path": "../..",
+        "type": "path"
+      },
+      "parent": []
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-patch-git-review-bump": "nixpkgs-patch-git-review-bump",
+        "nixpkgs-patcher": "nixpkgs-patcher"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/tests/expose-patched-nixpkgs/flake.nix
+++ b/tests/expose-patched-nixpkgs/flake.nix
@@ -1,0 +1,64 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/dd90a8666b501e6068a1d56fe6f0b1da85ccac06";
+    nixpkgs-patcher.url = "../..";
+    nixpkgs-patch-git-review-bump = {
+      url = "https://github.com/NixOS/nixpkgs/pull/410328.diff";
+      flake = false;
+    };
+  };
+
+  outputs =
+    inputs: with inputs; {
+      nixosConfigurations.patched = nixpkgs-patcher.lib.nixosSystem {
+        modules = [
+          ./base-configuration.nix
+          (
+            {
+              pkgs,
+              nixpkgs-patched,
+              ...
+            }:
+            let
+              pkgs-patched = import nixpkgs-patched {
+                inherit (pkgs) system;
+              };
+            in
+            {
+              nixpkgs.overlays = [
+                (final: prev: {
+                  inherit (pkgs-patched) git-review;
+                })
+              ];
+            }
+          )
+        ];
+        specialArgs = inputs;
+      };
+
+      nixosConfigurations.unpatched = nixpkgs.lib.nixosSystem {
+        modules = [
+          ./base-configuration.nix
+        ];
+        specialArgs = inputs;
+      };
+
+      checks.x86_64-linux.tests =
+        let
+          inherit (self.nixosConfigurations) patched unpatched;
+          lib = import ../lib.nix { inherit nixpkgs; };
+        in
+        lib.runTests {
+          testUnpatchedSystemBuilds = lib.testNixosConfigurationBuilds unpatched;
+          testPatchedSystemBuilds = lib.testNixosConfigurationBuilds patched;
+          testUnpatchedPackageVersion = {
+            expr = unpatched.pkgs.git-review.version;
+            expected = "2.4.0";
+          };
+          testPatchedPackageVersion = {
+            expr = patched.pkgs.git-review.version;
+            expected = "2.5.0";
+          };
+        };
+    };
+}


### PR DESCRIPTION
Should fix https://github.com/gepbird/nixpkgs-patcher/issues/5.

@doronbehar does this fit your needs?

Or maybe you're looking for a dedicated function like `nixpkgs-patcher.lib.patch-nixpkgs { inherit inputs system; }` to use it outside of a `nixosSystem`?

(sorry for pinging the wrong person initially :facepalm: )