### PR TITLE
fix: only use breakpointHook on Linux

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,7 @@
 
           nativeBuildInputs = with pkgs; [
             bat
+          ] ++ lib.optionals stdenv.buildPlatform.isLinux [
             breakpointHook
           ];
 


### PR DESCRIPTION
As `breakpointHook` is marked broken on non-Linux platforms ([here](https://github.com/NixOS/nixpkgs/blob/234939929861cc2558d02586a834ede24b6a6f32/pkgs/by-name/br/breakpointHook/package.nix#L25)), attempting to use `nixpkgs-patcher` via `patchNixpkgs` on Darwin fails to evaluate. 

This PR makes the addition of `breakPoint` hook conditional to only Linux systems.