### PR TITLE
`flake-input-patcher` can modify other flakes' inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ However, if you want to patch other flake inputs, check out the alternatives!
 | Works for any flake on GitHub                                                             | ❌ | ✅ | ✅ |
 | Works for any flake                                                                       | ❌ | ❌ | ✅ |
 | [IFD](https://nix.dev/manual/nix/2.29/language/import-from-derivation) free               | ❌ | ✅ | ❌ |
-| Can be used for modifying other flake inputs' `nixpkgs`                                   | ❌ | ✅ | ❌ |
+| Can be used for modifying other flake inputs' `nixpkgs`                                   | ❌ | ✅ | ✅ |
 
 ### Why Not Just Use Overlays?
 


### PR DESCRIPTION
I missed the discussion on <https://github.com/gepbird/nixpkgs-patcher/pull/8#discussion_r3239424725>

Also added a line about whether or not those patches will follow any
`inputs.follows` you've set up.
- `flake-input-patcher` just got this feature:
  <https://github.com/jfly/flake-input-patcher/pull/3>
- `nix-patcher` gets that behavior for free because it just creates a
  regular branch for you to use.
