### PR TITLE
fix: don't drop version metadata when merging into metadataModule

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -92,24 +92,25 @@
             systemAttrs: systemAttrs."${systemType}" or (die "${systemType} is an invalid system type.");
 
           metadataModule =
-            selectSystem {
-              nixosSystem.config = {
-                system.nixos.versionSuffix = ".${nixpkgsVersion { inherit nixpkgs patches; }}";
-                system.nixos.revision = nixpkgs.rev or "dirty";
+            nixpkgs.lib.recursiveUpdate
+              (selectSystem {
+                nixosSystem.config = {
+                  system.nixos.versionSuffix = ".${nixpkgsVersion { inherit nixpkgs patches; }}";
+                  system.nixos.revision = nixpkgs.rev or "dirty";
+                };
+                darwinSystem.config = {
+                  system.darwinVersionSuffix = ".${nixpkgsVersion { inherit nixpkgs patches; }}";
+                  system.darwinRevision = nixpkgs.rev or "dirty";
+                };
+              })
+              {
+                config = {
+                  # this should be using `finalNixpkgs` rather than `nixpkgs`
+                  # but that will slow down every command that tries to look up the nixpkgs flake
+                  # with the message 'copying "/nix/store/AAA..-patched" to the store'
+                  nixpkgs.flake.source = toString nixpkgs;
+                };
               };
-              darwinSystem.config = {
-                system.darwinVersionSuffix = ".${nixpkgsVersion { inherit nixpkgs patches; }}";
-                system.darwinRevision = nixpkgs.rev or "dirty";
-              };
-            }
-            // {
-              config = {
-                # this should be using `finalNixpkgs` rather than `nixpkgs`
-                # but that will slow down every command that tries to look up the nixpkgs flake
-                # with the message 'copying "/nix/store/AAA..-patched" to the store'
-                nixpkgs.flake.source = toString nixpkgs;
-              };
-            };
 
           nixpkgsPatcherNixosModule =
             { lib, ... }:

--- a/tests/advanced/flake.nix
+++ b/tests/advanced/flake.nix
@@ -93,6 +93,14 @@
             expr = patched.config.services ? lact;
             expected = true;
           };
+          testUnpatchedVersionSuffix = {
+            expr = builtins.match "^\\.[0-9]+\\.[0-9a-f]+$" unpatched.config.system.nixos.versionSuffix != null;
+            expected = true;
+          };
+          testPatchedVersionSuffix = {
+            expr = builtins.match "^\\.[0-9]+\\.[0-9a-f]+-patched$" patched.config.system.nixos.versionSuffix != null;
+            expected = true;
+          };
         };
     };
 }


### PR DESCRIPTION
`metadataModule` set `system.nixos.versionSuffix` and `system.nixos.revision` (or the darwin equivalents) via `selectSystem`, then used `//` to add `nixpkgs.flake.source` under the same `config` attribute. Because `//` is a shallow merge, the right-hand `config` fully replaced the left-hand one, silently discarding the version suffix and revision definitions.

As a result the system fell back to nixpkgs' built-in defaults (`versionSuffix = "pre-git"`, `revision = null`) instead of the patcher-computed `<date>.<shortRev>[-patched]` value — most visible when there are no patches, where this module is the only thing that would set them.

Use `lib.recursiveUpdate` so all three definitions survive the merge.