### PR TITLE
feat: expose patched nixpkgs as read-only nixpkgs-patcher.patchedNixpkgs

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -130,3 +130,18 @@ For example trying to query the hostname of an aarch64-linux host on an x86_64-l
 ```
 
 This can be useful when using [nixpkgs-patcher with NixOS-DNS](https://github.com/gepbird/nixpkgs-patcher/issues/4).
+
+### Reusing the Patched nixpkgs
+
+You can obtain the patched nixpkgs instance by reading `config.nixpkgs-patcher.patchedNixpkgs`.
+
+This is handy when you want some other part of your configuration to use the exact same patched nixpkgs the system was built from, without calling `patchNixpkgs` a second time. A common case is pointing a `nixpkgs=...` `NIX_PATH` entry at it, so legacy tooling resolving `<nixpkgs>` sees the same source as your system:
+
+```nix
+# file: configuration.nix
+{ config, ... }:
+
+{
+  nix.nixPath = [ "nixpkgs=${config.nixpkgs-patcher.patchedNixpkgs}" ];
+}
+```

--- a/flake.nix
+++ b/flake.nix
@@ -125,6 +125,29 @@
             {
               options.nixpkgs-patcher = {
                 enable = mkEnableOption "nixpkgs-patcher";
+                patchedNixpkgs = mkOption {
+                  type = types.path;
+                  default = finalNixpkgs;
+                  readOnly = true;
+                  description = ''
+                    The nixpkgs source this system was evaluated against, with
+                    all patches applied (equal to the unpatched nixpkgs when
+                    there are no patches).
+
+                    Exposed so you can reuse the exact same patched nixpkgs
+                    elsewhere in your configuration — for example as the target
+                    of a `nixpkgs=...` `NIX_PATH` entry, so legacy tooling
+                    resolves `<nixpkgs>` to the same source the system was built
+                    from:
+
+                    ```nix
+                    { config, ... }:
+                    {
+                      nix.nixPath = [ "nixpkgs=${config.nixpkgs-patcher.patchedNixpkgs}" ];
+                    }
+                    ```
+                  '';
+                };
                 settings = mkOption {
                   type = types.submodule {
                     options = {

--- a/tests/advanced/flake.nix
+++ b/tests/advanced/flake.nix
@@ -78,14 +78,43 @@
         ];
       };
 
+      # built through the patcher but with no patches, to exercise the path where
+      # patchedNixpkgs falls back to the unpatched base nixpkgs
+      nixosConfigurations.patchless = nixpkgs-patcher.lib.nixosSystem {
+        modules = [
+          ./configuration.nix
+          ./hardware-configuration.nix
+        ];
+        nixpkgsPatcher = {
+          inherit inputs;
+          nixpkgs = nixpkgs-unstable;
+          patchInputRegex = "^no-such-patch-input-.*";
+        };
+      };
+
       checks.x86_64-linux.tests =
         let
-          inherit (self.nixosConfigurations) patched patchedWithFlakeSource unpatched;
+          inherit (self.nixosConfigurations)
+            patched
+            patchedWithFlakeSource
+            unpatched
+            patchless
+            ;
           lib = import ../lib.nix { nixpkgs = nixpkgs-unstable; system = "x86_64-linux"; };
         in
         lib.runTests {
           testUnpatchedSystemBuilds = lib.testNixosConfigurationBuilds unpatched;
           testPatchedSystemBuilds = lib.testNixosConfigurationBuilds patched;
+          # with patches, patchedNixpkgs is the patched source, not the base input
+          testPatchedNixpkgsIsPatched = {
+            expr = (toString patched.config.nixpkgs-patcher.patchedNixpkgs) == (toString nixpkgs-unstable.outPath);
+            expected = false;
+          };
+          # without patches, patchedNixpkgs is exactly the base nixpkgs input
+          testPatchedNixpkgsIsBaseWhenNoPatches = {
+            expr = (toString patchless.config.nixpkgs-patcher.patchedNixpkgs) == (toString nixpkgs-unstable.outPath);
+            expected = true;
+          };
           testUnpatchedOsuVersion = {
             expr = unpatched.pkgs.osu-lazer-bin.version;
             expected = "2025.424.0";


### PR DESCRIPTION
After patching, the nixpkgs source the system was evaluated against (`finalNixpkgs`) was only available internally. Reusing it elsewhere — most commonly to point a `nixpkgs=...` NIX_PATH entry at the same patched source so legacy `<nixpkgs>` tooling matches the system — required calling `patchNixpkgs` a second time with the same arguments, duplicating work and risking drift if the arguments diverge.

Expose it as a read-only NixOS/nix-darwin option `nixpkgs-patcher.finalNixpkgs`. The value is set only on the final system evaluation, not on the internal `evaledModules` probe eval: `finalNixpkgs` depends on `patches`, which is read back from
`evaledModules`, so assigning it there would be infinite recursion.